### PR TITLE
Remove unnecessary do_slam arg from airsim launcher

### DIFF
--- a/launch/airsim.launch
+++ b/launch/airsim.launch
@@ -1,6 +1,5 @@
 <launch>
 
-    <arg name="do_slam" default="true"/>
     <arg name="vehicle_name" default="MyVehicle"/>
     <arg name="vehicle_frame" default="base_link"/>
     <arg name="odom_frame" default="odom"/>
@@ -25,15 +24,13 @@
         <param name="enable_cameras" value="$(arg enable_cameras)" />
     </node>
 
-    <group if="$(arg do_slam)">
-        <include file="$(find rs_to_velodyne)/launch/rs_to_velodyne.launch">
-            <arg name="raw_lidar_topic" value="$(arg raw_lidar_topic)"/>
-            <arg name="input_cloud_type" value="XYZI"/>
-            <arg name="output_cloud_type" value="XYZIR"/>
-        </include>
+    <node pkg="tf" type="static_transform_publisher" name="velodyne_pub" args="0 0 0 0 0 0 base_link/Lidar2 velodyne 100"/>
 
-        <node pkg="tf" type="static_transform_publisher" name="velodyne_pub" args="0 0 0 0 0 0 base_link/Lidar2 velodyne 100"/>
-    </group>
+    <include file="$(find rs_to_velodyne)/launch/rs_to_velodyne.launch">
+        <arg name="raw_lidar_topic" value="$(arg raw_lidar_topic)"/>
+        <arg name="input_cloud_type" value="XYZI"/>
+        <arg name="output_cloud_type" value="XYZIR"/>
+    </include>
 
     <node type="rviz" name="airsim_rviz" pkg="rviz" args="-d $(find vehicle_launch)/config/airsim.rviz" output="log"/>
 </launch>

--- a/launch/decco.launch
+++ b/launch/decco.launch
@@ -70,7 +70,6 @@
 
     <!-- Simulation -->
     <include file="$(find vehicle_launch)/launch/airsim.launch" if="$(arg simulate)">
-        <arg name="do_slam" value="$(arg do_slam)"/>
         <arg name="enable_cameras" value="$(arg enable_cameras)"/>
         <arg name="vehicle_name" value="$(arg vehicle_name)"/>
     </include>


### PR DESCRIPTION
Before, we would only launch rs_to_velodyne if do_slam=true, but we don't need to make this distinction. 