### PR TITLE
Moved species mapping and vegetation to offline only launch

### DIFF
--- a/launch/decco.launch
+++ b/launch/decco.launch
@@ -50,7 +50,7 @@
     <arg name="do_exploration" default="true"/>
     <arg name="do_rangedata_oa" default="true"/>
     <arg name="do_vegetation" default="true"/>
-    <arg name="do_species_map" default="true"/> 
+    <arg name="do_species_map" default="false"/> <!-- Only enable when required e.g. for ASH -->
     <arg name="do_record" default="true" unless="$(eval simulate + offline)"/>
     <arg name="do_record" default="false" if="$(eval simulate + offline)"/>
 


### PR DESCRIPTION
Moved everything that can be done in postprocessing to only run when offline:=true

Test by running the usual decco.launch and confirm that vegetation is not running, and image_segment is (but species_mapper is not)