### PR TITLE
Adding mag data and removing map yaw

### DIFF
--- a/config/r88_default.config
+++ b/config/r88_default.config
@@ -17,6 +17,7 @@
 /mavros/global_position/global
 /mavros/global_position/rel_alt
 /mavros/imu/data
+/mavros/imu/mag
 /mavros/local_position/pose
 /mavros/setpoint_position/local
 /mavros/setpoint_raw/local
@@ -28,7 +29,6 @@
 /seek_thermal/camera_info
 /setpoint_viz
 /task_manager/map_region
-/task_manager/map_yaw
 /task_manager/task_status
 /thermal_cam/camera_info
 /tf


### PR DESCRIPTION
Mag data is raw magnetometer data which might be useful in the future in debugging orientation issues. 