### PR TITLE
Adding cube symlink to decco rules

### DIFF
--- a/config/99-decco.rules
+++ b/config/99-decco.rules
@@ -1,3 +1,7 @@
+SUBSYSTEM=="tty", ATTRS{bInterfaceNumber}!="00", GOTO="cube"
+ACTION=="add", ATTRS{idVendor}=="2dae", ATTRS{idProduct}=="1058", SYMLINK+="cubeorange"
+LABEL="cube"
+
 ACTION=="add", SUBSYSTEM=="video4linux", ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="f9f9", ATTR{index}=="0", SYMLINK+="attollo"
 ACTION=="add", SUBSYSTEM=="video4linux", ATTRS{idVendor}=="0603", ATTRS{idProduct}=="8612", ATTR{index}=="0", SYMLINK+="mapir"
 ACTION=="add", SUBSYSTEM=="video4linux", ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="5830", ATTR{index}=="0", SYMLINK+="seek_thermal"


### PR DESCRIPTION
This was on the decco itself but not in vehicle launch. 